### PR TITLE
Starting at line 205;

### DIFF
--- a/application/views/widgets/vehicle_reference_system.php
+++ b/application/views/widgets/vehicle_reference_system.php
@@ -202,19 +202,19 @@ class vehicle_reference_system_widget extends WP_Widget {
 						$thumbnail = urldecode( $model->image_urls->small );
 						echo '<div class="vrs-widget-item">';
 						echo '<a href="' . $inventory_url . '" title="' . $generic_vehicle_title . '">';
-						echo '<div class="vrs-widget-thumbnail"><img src="' . $thumbnail . '" alt="' . $generic_vehicle_title . '" title="' . $generic_vehicle_title . '" /></div>';
-						echo '<div class="vrs-widget-main-line">';
-						echo '<div class="vrs-widget-make">' . $model->name . '</div>';
-						echo '</div>';
+						echo '<span class="vrs-widget-thumbnail"><img src="' . $thumbnail . '" alt="' . $generic_vehicle_title . '" title="' . $generic_vehicle_title . '" /></span>';
+						echo '<span class="vrs-widget-main-line">';
+						echo '<span class="vrs-widget-make">' . $model->name . '</span>';
+						echo '</span>';
 						echo '</a>';
 						echo '</div>';
 					}
 				}
 			} else {
 				echo '<div class="vrs-widget-item">';
-					echo '<div class="vrs-widget-main-line">';
+					echo '<span class="vrs-widget-main-line">';
 					echo '<p>Data Not Available.</p>';
-					echo '</div>';
+					echo '</span>';
 				echo '</div>';
 			}
 			echo '</div>';


### PR DESCRIPTION
changed div tags to span. w3c html 4.+ and xhtml standard compliance doesn't allow for default block level elements nested inside a tags. Changed nested elements to span tags that can be displayed as block level but still meet xhtml standards. Note: html5 allows for block level and other html elements to be nested inside a tags.
Digging through W3C compliance to long. Reference here: 
http://stackoverflow.com/questions/4153887/xhtml-inline-div-inside-anchor-tag
Hope I did this correct. Will go to VMS and fork it next.
